### PR TITLE
The second parameter is required. Without it the addon not works and …

### DIFF
--- a/app/addons/notification_events_example/Tygh/Addons/NotificationEventsExample/Notifications/Transports/Stub/StubTransport.php
+++ b/app/addons/notification_events_example/Tygh/Addons/NotificationEventsExample/Notifications/Transports/Stub/StubTransport.php
@@ -23,10 +23,11 @@ class StubTransport implements ITransport
      * Processes a message of an event.
      *
      * @param \Tygh\Notifications\Transports\BaseMessageSchema $schema Schema
+     * @param \Tygh\Notifications\Receivers\SearchCondition[]  $receiver_search_conditions
      *
      * @return bool Whether a message was successfully processed
      */
-    public function process(BaseMessageSchema $schema)
+    public function process(BaseMessageSchema $schema, array $receiver_search_conditions)
     {
         if (!$schema instanceof StubMessageSchema) {
             throw new DeveloperException('Input data should be instance of StubMessageSchema');


### PR DESCRIPTION
I tried to figure out with the notifications on cs-cart and took this addon. But it not only works as expected but crushes the store when one tryes to create a notification or goes to control the notification. All that is because the overridden function doesn't contain the second parametr.